### PR TITLE
fix: update documentation to reflect MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/zhengxii921/covmapy/actions/workflows/ci.yml/badge.svg)](https://github.com/zhengxii921/covmapy/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/zhengxii921/covmapy/branch/main/graph/badge.svg)](https://codecov.io/gh/zhengxii921/covmapy)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/zhengxii921/covmapy?utm_source=oss&utm_medium=github&utm_campaign=zhengxii921%2Fcovmapy&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 
 A Python CLI tool that visualizes test coverage data as interactive treemap charts.
@@ -62,4 +62,4 @@ covmapy coverage.xml --output coverage-report.html
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Coverage visualization tool that generates interactive treemaps"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "Apache-2.0"}
+license = {text = "MIT"}
 authors = []
 dependencies = [
     "click>=8.0,<9.0",


### PR DESCRIPTION
## Summary

This PR fixes the documentation to properly reflect the MIT license that was adopted in the codebase. The LICENSE file was already updated to MIT, but some documentation files still referenced Apache 2.0.

### Changes made:

- Updated README.md license badge from Apache 2.0 to MIT
- Updated README.md license section text to reference MIT License  
- Updated pyproject.toml license declaration from "Apache-2.0" to "MIT"

### Context

These changes complete the license migration from Apache 2.0 to MIT by updating the documentation that was missed in the initial license change. This ensures consistency across all project files.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project license information in the README to reflect the switch from Apache 2.0 to MIT.
  * Changed the license badge and related details in the README accordingly.

* **Chores**
  * Updated license metadata in project configuration to MIT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->